### PR TITLE
Replace dp and sp with Dimens object

### DIFF
--- a/app/src/main/java/az/lahza/hoqqaqr/ui/components/ColorPickerDialog.kt
+++ b/app/src/main/java/az/lahza/hoqqaqr/ui/components/ColorPickerDialog.kt
@@ -22,10 +22,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import az.lahza.hoqqaqr.R
+import az.lahza.hoqqaqr.ui.theme.Dimens
 
 /**
  * A customizable color picker dialog that allows users to select a color by adjusting
@@ -54,18 +53,18 @@ fun ColorPickerDialog(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp)
-                .background(Color.White, shape = RoundedCornerShape(12.dp))
+                .padding(Dimens._16DP)
+                .background(Color.White, shape = RoundedCornerShape(Dimens.ExtraLarge))
         ) {
             Column(
-                modifier = Modifier.padding(16.dp),
+                modifier = Modifier.padding(Dimens._16DP),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
                     text = stringResource(id = R.string.select_color),
-                    fontSize = 18.sp,
+                    fontSize = Dimens._18SP,
                     fontFamily = FontFamily(Font(R.font.manrope_bold)),
-                    modifier = Modifier.padding(bottom = 16.dp)
+                    modifier = Modifier.padding(bottom = Dimens._16DP)
                 )
                 val red = remember { mutableFloatStateOf(initialColor.red) }
                 val green = remember { mutableFloatStateOf(initialColor.green) }
@@ -95,25 +94,25 @@ fun ColorPickerDialog(
                     label = stringResource(id = R.string.blue_label)
                 )
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(Dimens._16DP))
 
                 val selectedColor = Color(red.floatValue, green.floatValue, blue.floatValue)
 
                 Box(
                     modifier = Modifier
-                        .border(1.dp, Color.Black, RoundedCornerShape(12.dp))
-                        .size(50.dp)
-                        .background(selectedColor, RoundedCornerShape(12.dp))
+                        .border(Dimens.ExtraSmall, Color.Black, RoundedCornerShape(Dimens.ExtraLarge))
+                        .size(Dimens._50DP)
+                        .background(selectedColor, RoundedCornerShape(Dimens.ExtraLarge))
                 )
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(Dimens._16DP))
 
                 Button(
                     onClick = {
                         onColorSelected(selectedColor)
                         onDismiss()
                     },
-                    shape = RoundedCornerShape(12.dp),
+                    shape = RoundedCornerShape(Dimens.ExtraLarge),
                     modifier = Modifier.fillMaxWidth(),
                     colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF0D7DF2)),
                 ) {

--- a/app/src/main/java/az/lahza/hoqqaqr/ui/components/ColorSlider.kt
+++ b/app/src/main/java/az/lahza/hoqqaqr/ui/components/ColorSlider.kt
@@ -7,7 +7,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.sp
+import az.lahza.hoqqaqr.ui.theme.Dimens
 
 /**
  * A composable that displays a slider for adjusting RGB color components,
@@ -32,7 +32,7 @@ fun ColorSlider(
     // Label Text for the Slider
     Text(
         text = "$label: ${(value * 255).toInt()}",
-        fontSize = 14.sp
+        fontSize = Dimens._14SP
     )
 
     // Slider Component for Color Adjustment

--- a/app/src/main/java/az/lahza/hoqqaqr/ui/components/ContentInputField.kt
+++ b/app/src/main/java/az/lahza/hoqqaqr/ui/components/ContentInputField.kt
@@ -16,9 +16,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import az.lahza.hoqqaqr.R
+import az.lahza.hoqqaqr.ui.theme.Dimens
 
 /**
  * A composable function that renders a labeled text input field for content entry.
@@ -38,25 +37,25 @@ import az.lahza.hoqqaqr.R
 fun ContentInputField(content: String, onValueChange: (String) -> Unit) {
     // Define common text styles to avoid redundancy
     val titleTextStyle = TextStyle(
-        fontSize = 22.sp,
+        fontSize = Dimens._22SP,
         fontFamily = FontFamily(Font(R.font.manrope_bold))
     )
 
     val labelTextStyle = TextStyle(
-        fontSize = 16.sp,
+        fontSize = Dimens._16SP,
         fontFamily = FontFamily(Font(R.font.manrope_medium))
     )
 
     Column {
         Text(
             text = stringResource(R.string.generate_qr_code_title),
-            modifier = Modifier.padding(bottom = 24.dp),
+            modifier = Modifier.padding(bottom = Dimens._24DP),
             style = titleTextStyle,
         )
 
         Text(
             text = stringResource(R.string.content_label),
-            modifier = Modifier.padding(bottom = 8.dp),
+            modifier = Modifier.padding(bottom = Dimens.MediumLarge),
             style = labelTextStyle,
         )
 
@@ -65,8 +64,8 @@ fun ContentInputField(content: String, onValueChange: (String) -> Unit) {
             onValueChange = onValueChange,
             modifier = Modifier
                 .fillMaxWidth()
-                .height(150.dp),
-            shape = RoundedCornerShape(12.dp),
+                .height(Dimens._150DP),
+            shape = RoundedCornerShape(Dimens.ExtraLarge),
             colors = TextFieldDefaults.outlinedTextFieldColors(
                 focusedBorderColor = Color.Gray, unfocusedBorderColor = Color.LightGray
             )

--- a/app/src/main/java/az/lahza/hoqqaqr/ui/components/CustomQrCodeDialog.kt
+++ b/app/src/main/java/az/lahza/hoqqaqr/ui/components/CustomQrCodeDialog.kt
@@ -21,10 +21,9 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import az.lahza.hoqqaqr.R
+import az.lahza.hoqqaqr.ui.theme.Dimens
 
 /**
  * A composable function that displays a dialog containing a generated QR code,
@@ -50,11 +49,11 @@ fun CustomQrCodeDialog(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp)
-                .background(Color.White, shape = RoundedCornerShape(12.dp))
+                .padding(Dimens._16DP)
+                .background(Color.White, shape = RoundedCornerShape(Dimens.ExtraLarge))
         ) {
             Column(
-                modifier = Modifier.padding(16.dp),
+                modifier = Modifier.padding(Dimens._16DP),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Box(
@@ -70,7 +69,7 @@ fun CustomQrCodeDialog(
 
                     Text(
                         text = stringResource(id = R.string.qr_code),
-                        fontSize = 18.sp,
+                        fontSize = Dimens._18SP,
                         fontFamily = FontFamily(Font(R.font.manrope_bold))
                     )
                 }
@@ -82,11 +81,11 @@ fun CustomQrCodeDialog(
                         modifier = Modifier
                             .fillMaxWidth()
                             .aspectRatio(1f)
-                            .padding(16.dp)
+                            .padding(Dimens._16DP)
                     )
                 }
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(Dimens._16DP))
 
                 // Buttons (Save to Gallery and Share)
                 ActionButtons(

--- a/app/src/main/java/az/lahza/hoqqaqr/ui/components/GenerateQrButton.kt
+++ b/app/src/main/java/az/lahza/hoqqaqr/ui/components/GenerateQrButton.kt
@@ -11,8 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import az.lahza.hoqqaqr.R
+import az.lahza.hoqqaqr.ui.theme.Dimens
 
 /**
  * A composable button that triggers the QR code generation process when clicked.
@@ -33,10 +33,10 @@ fun GenerateQrButton(
     ) {
         Button(
             onClick = onClick,
-            shape = RoundedCornerShape(12.dp),
+            shape = RoundedCornerShape(Dimens.ExtraLarge),
             modifier = Modifier
                 .fillMaxWidth()
-                .height(56.dp),
+                .height(Dimens._56DP),
             colors = ButtonDefaults.buttonColors(
                 containerColor = Color(0xFF0D7DF2),
                 contentColor = Color.White,

--- a/app/src/main/java/az/lahza/hoqqaqr/ui/components/Header.kt
+++ b/app/src/main/java/az/lahza/hoqqaqr/ui/components/Header.kt
@@ -12,9 +12,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import az.lahza.hoqqaqr.R
+import az.lahza.hoqqaqr.ui.theme.Dimens
 
 /**
  * A composable that displays a header with a title, typically used in the main screen of the app.
@@ -30,14 +29,14 @@ import az.lahza.hoqqaqr.R
 fun Header() {
     // Define the common text style
     val headerTextStyle = TextStyle(
-        fontSize = 22.sp,
+        fontSize = Dimens._22SP,
         fontFamily = FontFamily(Font(R.font.manrope_medium))
     )
 
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(bottom = 16.dp),
+            .padding(bottom = Dimens._16DP),
         horizontalArrangement = Arrangement.Start,
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/app/src/main/java/az/lahza/hoqqaqr/ui/components/OptionalSettings.kt
+++ b/app/src/main/java/az/lahza/hoqqaqr/ui/components/OptionalSettings.kt
@@ -13,9 +13,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import az.lahza.hoqqaqr.R
+import az.lahza.hoqqaqr.ui.theme.Dimens
 
 /**
  * A composable that displays a list of optional settings for the user to modify.
@@ -51,15 +50,15 @@ fun OptionalSettings(
         // Title text
         Text(
             text = stringResource(R.string.optional_settings),
-            modifier = Modifier.padding(bottom = 8.dp),
-            fontSize = 18.sp,
+            modifier = Modifier.padding(bottom = Dimens.MediumLarge),
+            fontSize = Dimens._18SP,
             fontFamily = FontFamily(Font(R.font.manrope_bold))
         )
 
         // Options list
         Column(
             modifier = Modifier.fillMaxWidth(),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+            verticalArrangement = Arrangement.spacedBy(Dimens.ExtraLarge),
         ) {
             listOf(
                 stringResource(R.string.dot_color_label),

--- a/app/src/main/java/az/lahza/hoqqaqr/ui/components/QrCodeDialog.kt
+++ b/app/src/main/java/az/lahza/hoqqaqr/ui/components/QrCodeDialog.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.platform.LocalContext
 import az.lahza.hoqqaqr.R
 import az.lahza.hoqqaqr.utils.saveBitmapToGallery
 
-
 /**
  * Displays a dialog with the generated QR code, and provides functionality to save the QR code to the device gallery.
  *

--- a/app/src/main/java/az/lahza/hoqqaqr/ui/components/SettingButton.kt
+++ b/app/src/main/java/az/lahza/hoqqaqr/ui/components/SettingButton.kt
@@ -12,8 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.dp
 import az.lahza.hoqqaqr.R
+import az.lahza.hoqqaqr.ui.theme.Dimens
 
 /**
  * A composable button component for displaying a selectable setting option.
@@ -59,12 +59,12 @@ fun SettingButton(
                 onClearClick(setting)
             },
             border = if (selectedSetting == setting) {
-                BorderStroke(2.dp, Color.Gray)
-            } else BorderStroke(1.dp, Color.LightGray),
-            shape = RoundedCornerShape(12.dp)
+                BorderStroke(Dimens.Small, Color.Gray)
+            } else BorderStroke(Dimens.ExtraSmall, Color.LightGray),
+            shape = RoundedCornerShape(Dimens.ExtraLarge)
         ) {
             Text(
-                modifier = Modifier.padding(vertical = 8.dp),
+                modifier = Modifier.padding(vertical = Dimens.MediumLarge),
                 text = setting,
                 color = Color.Black,
                 fontFamily = FontFamily(Font(R.font.manrope_medium))

--- a/app/src/main/java/az/lahza/hoqqaqr/ui/screens/GenerateQrCodeScreen.kt
+++ b/app/src/main/java/az/lahza/hoqqaqr/ui/screens/GenerateQrCodeScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.unit.dp
 import az.lahza.hoqqaqr.R
 import az.lahza.hoqqaqr.constants.MimeTypes
 import az.lahza.hoqqaqr.extensions.empty
@@ -34,6 +33,7 @@ import az.lahza.hoqqaqr.ui.components.GenerateQrButton
 import az.lahza.hoqqaqr.ui.components.Header
 import az.lahza.hoqqaqr.ui.components.OptionalSettings
 import az.lahza.hoqqaqr.ui.components.QrCodeDialog
+import az.lahza.hoqqaqr.ui.theme.Dimens
 import az.lahza.hoqqaqr.utils.generateQRCode
 
 /**
@@ -114,11 +114,11 @@ fun GenerateQrCodeScreen(innerPadding: PaddingValues) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(16.dp)
+                .padding(Dimens._16DP)
         ) {
             Header()
             ContentInputField(content, onValueChange = { content = it })
-            Spacer(modifier = Modifier.height(20.dp))
+            Spacer(modifier = Modifier.height(Dimens._20DP))
             OptionalSettings(
                 isSettingsChanged = isSettingsChanged,
                 selectedSetting = selectedSetting,
@@ -151,7 +151,7 @@ fun GenerateQrCodeScreen(innerPadding: PaddingValues) {
 
         GenerateQrButton(
             modifier = Modifier
-                .padding(horizontal = 16.dp, vertical = 32.dp)
+                .padding(horizontal = Dimens._16DP, vertical = Dimens._32DP)
                 .align(Alignment.BottomCenter),
             onClick = {
                 if (content.isEmpty()) {

--- a/app/src/main/java/az/lahza/hoqqaqr/ui/theme/Dimens.kt
+++ b/app/src/main/java/az/lahza/hoqqaqr/ui/theme/Dimens.kt
@@ -1,7 +1,27 @@
 package az.lahza.hoqqaqr.ui.theme
 
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
+/**
+ * Sizes:
+ * DP
+ * ```kotlin
+ *  ExtraSmall = 1.dp
+ *  Small = 2.dp
+ *  SmallMedium = 4.dp
+ *  Medium = 6.dp
+ *  MediumLarge = 8.dp
+ *  Large = 10.dp
+ *  ExtraLarge = 12.dp
+ *  _2XLarge = 14.dp
+ *  _3XLarge = 16.dp
+ *  _4XLarge = 18.dp
+ *  _5XLarge = 20.dp
+ *  _6XLarge = 22.dp
+ *  _7XLarge = 24.dp
+ * ```
+ */
 object Dimens {
     val ExtraSmall = 1.dp
     val Small = 2.dp
@@ -10,10 +30,20 @@ object Dimens {
     val MediumLarge = 8.dp
     val Large = 10.dp
     val ExtraLarge = 12.dp
-    val _2XLarge = 14.dp
-    val _3XLarge = 16.dp
-    val _4XLarge = 18.dp
-    val _5XLarge = 20.dp
-    val _6XLarge = 22.dp
-    val _7XLarge = 24.dp
+    val _14DP = 14.dp
+    val _16DP = 16.dp
+    val _18DP = 18.dp
+    val _20DP = 20.dp
+    val _22DP = 22.dp
+    val _24DP = 24.dp
+    val _32DP = 32.dp
+    val _50DP = 50.dp
+    val _56DP = 56.dp
+    val _150DP = 150.dp
+
+    val _12SP = 12.sp
+    val _14SP = 14.sp
+    val _16SP = 16.sp
+    val _18SP = 18.sp
+    val _22SP = 22.sp
 }


### PR DESCRIPTION
This PR refactors the codebase by replacing hardcoded `dp` and `sp` values with centralized references from the `Dimens` object.

### Changes Made
- Replaced hardcoded `dp` values with corresponding entries from the `Dimens` object.
- Replaced hardcoded `sp` values with references from the `Dimens` object.
- Updated layouts and style files to use the `Dimens` object for improved consistency and maintainability.

### Why This Change?
- **Consistency:** Ensures uniform use of dimensions across the project.
- **Maintainability:** Centralized dimensions make it easier to update values when design changes occur.
- **Best Practices:** Aligns with the principle of managing constants from a single source of truth.
